### PR TITLE
Close the stats file once it is downloaded

### DIFF
--- a/src/scraper/downloader.cpp
+++ b/src/scraper/downloader.cpp
@@ -32,6 +32,7 @@ namespace
          curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, Curl::write);
          curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
          res = curl_easy_perform(curl);
+         fclose(fp);
       }
 
       CURL *curl;


### PR DESCRIPTION
File needs to be close in order to release the handle for future operations. This broke the gunzip decompression before.